### PR TITLE
Wanted to implement auto-update on macOS but decided to postpone it.

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -28,7 +28,7 @@
     "hardenedRuntime": true,
     "gatekeeperAssess": false,
     "entitlements": "script/notarize/entitlements.mac.plist",
-    "entitlementsInherit": "script/notarize/entitlements.mac.plist",
+    "entitlementsInherit": "script/notarize/entitlements.mac.plist"
   },
   "linux": {
     "icon": "dist",


### PR DESCRIPTION
In short, implementing auto-update is postponed due to an electron-builder issue. For this PR, only a small update regarding JSON specification is checked in.


Here is the story:

To enable auto-update, both dmg and zip need to be published.
https://github.com/electron-userland/electron-builder/issues/2199

The electron-builder configuration will contain the following content:

```
  "mac": {
    ...
    "target": [
      "dmg",
      "zip"
    ],
    ....
  },
```

However, as of November 9, 2019, when starting the application extracted from zip file, a message "The application Photo Location Map can't be opened" pops up. There is an open GitHub issue regarding electron-builder.
https://github.com/electron-userland/electron-builder/issues/4299

I decided to postpone implementing auto-update on macOS until the electron-builder issue is resolved.