### PR TITLE
Fix file path for img src on photo info viewer on macOS.

### DIFF
--- a/src/app/photo-info-viewer/photo-info-viewer-content.ts
+++ b/src/app/photo-info-viewer/photo-info-viewer-content.ts
@@ -47,7 +47,7 @@ export class PhotoInfoViewerContent {
     } else {
       // # needs to be escaped. See https://www.w3schools.com/tags/ref_urlencode.asp for encoding.
       const escapedPath = photo.path.replace(/#/g, '%23');
-      thumbnailElement.src = escapedPath;
+      thumbnailElement.src = `file://${escapedPath}`;
       const largerSideLength = 200;
       if (photo.dimensions.width > photo.dimensions.height) {
         thumbnailElement.width = largerSideLength;


### PR DESCRIPTION
On macOS, the file path is like `/Users/a/b/c`.
For live-reload mode, the file path will be `http://localhost:4200/Users/a/b/c`, which is incorrect.
Prepending `file://` solves this problem.