### PR TITLE
Remove polyfills-test.ts

### DIFF
--- a/src/polyfills-test.ts
+++ b/src/polyfills-test.ts
@@ -1,3 +1,0 @@
-import 'core-js/es/reflect';
-import 'zone.js/dist/zone';
-


### PR DESCRIPTION
Because this is no longer required after start using polyfills.ts.