### PR TITLE
Support PNG/TIFF files to some extent.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 Tomoyuki Aota
+Copyright (c) 2019-2021 Tomoyuki Aota
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/angular.json
+++ b/angular.json
@@ -36,9 +36,8 @@
           "configurations": {
             "dev": {
               "optimization": false,
-              "outputHashing": "all",
+              "outputHashing": "none",
               "sourceMap": true,
-              "extractCss": true,
               "namedChunks": false,
               "aot": false,
               "extractLicenses": true,
@@ -53,9 +52,8 @@
             },
             "production": {
               "optimization": true,
-              "outputHashing": "all",
-              "sourceMap": false,
-              "extractCss": true,
+              "outputHashing": "none",
+              "sourceMap": true,
               "namedChunks": false,
               "aot": true,
               "extractLicenses": true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "npm run electron:serve-tsc && ng build",
     "build:dev": "npm run build -- -c dev",
     "build:prod": "npm run build -- -c production",
-    "ng:serve": "ng serve",
+    "ng:serve": "ng serve -c production",
     "electron:serve-tsc": "tsc -p tsconfig.serve.json",
     "electron:serve": "wait-on http-get://localhost:4200/ && npm run electron:serve-tsc && electron . --serve",
     "electron:local": "npm run build:prod && electron .",

--- a/src-shared/filename-extension/filename-extension.ts
+++ b/src-shared/filename-extension/filename-extension.ts
@@ -16,6 +16,8 @@ export class FilenameExtension {
 
   private static readonly extensionsSupportedByExifr: ReadonlyArray<string> = [
     ...FilenameExtension.jpegExtensions,
+    ...FilenameExtension.tiffExtensions,
+    ...FilenameExtension.pngExtensions,
     ...FilenameExtension.heifExtensions,
   ];
 
@@ -24,8 +26,8 @@ export class FilenameExtension {
   ];
 
   private static readonly extensionsDisplayableInBrowser: ReadonlyArray<string> = [
-    ...FilenameExtension.jpegExtensions
-    // TODO: Add PNG and WebP here when supporting them.
+    ...FilenameExtension.jpegExtensions,
+    ...FilenameExtension.pngExtensions,
   ];
 
   public static isSupportedByPlm(extension: string) {


### PR DESCRIPTION
Most PNG files do not contain EXIF, so they won't be displayed on the map. The thumbnails are available in the directory tree pane.

TIFF files contain EXIF, but Chromium does not support displaying the files, so they are available on the map but the thumbnails are not shown.