### PR TITLE
Remove HammerJS.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,6 @@
         "eslint": "8.10.0",
         "espower-typescript": "10.0.0",
         "exif-parser": "0.1.12",
-        "hammerjs": "2.0.8",
         "jasmine-core": "4.0.1",
         "karma": "6.3.17",
         "karma-coverage-istanbul-reporter": "3.0.3",
@@ -12528,15 +12527,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.x"
-      }
-    },
-    "node_modules/hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/handle-thing": {
@@ -31082,12 +31072,6 @@
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
-    },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
       "dev": true
     },
     "handle-thing": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "eslint": "8.10.0",
     "espower-typescript": "10.0.0",
     "exif-parser": "0.1.12",
-    "hammerjs": "2.0.8",
     "jasmine-core": "4.0.1",
     "karma": "6.3.17",
     "karma-coverage-istanbul-reporter": "3.0.3",


### PR DESCRIPTION
HammerJS was added when Angular Material was introduced.
This PR removes HammerJS because Angular Material no longer requires it from version 9.