### PR TITLE
Adjust the log level of trackEvent from error to warn.

### DIFF
--- a/src-shared/analytics/library-wrapper/amplitude-analytics-browser-wrapper.ts
+++ b/src-shared/analytics/library-wrapper/amplitude-analytics-browser-wrapper.ts
@@ -31,7 +31,7 @@ export class AmplitudeAnalyticsBrowserWrapper {
   @AnalyticsLibraryWrapperTrackEvent(amplitudeLogger)
   public static trackEvent(category: string, action: string, label?: string, value?: string | number) {
     if (!this.isInitialized) {
-      amplitudeLogger.error('AmplitudeAnalyticsBrowserWrapper::initialize needs to be called before calling AmplitudeAnalyticsBrowserWrapper::trackEvent');
+      amplitudeLogger.warn('AmplitudeAnalyticsBrowserWrapper::initialize needs to be called before calling AmplitudeAnalyticsBrowserWrapper::trackEvent');
       return;
     }
 

--- a/src-shared/analytics/library-wrapper/mixpanel-browser-wrapper.ts
+++ b/src-shared/analytics/library-wrapper/mixpanel-browser-wrapper.ts
@@ -29,7 +29,7 @@ export class MixpanelBrowserWrapper {
   @AnalyticsLibraryWrapperTrackEvent(mixpanelLogger)
   public static trackEvent(category: string, action: string, label?: string, value?: string | number) {
     if (!this.isInitialized) {
-      mixpanelLogger.error('MixpanelBrowserWrapper::initialize needs to be called before calling MixpanelBrowserWrapper::trackEvent');
+      mixpanelLogger.warn('MixpanelBrowserWrapper::initialize needs to be called before calling MixpanelBrowserWrapper::trackEvent');
       return;
     }
 

--- a/src-shared/analytics/library-wrapper/universal-analytics-wrapper.ts
+++ b/src-shared/analytics/library-wrapper/universal-analytics-wrapper.ts
@@ -38,7 +38,7 @@ export class UniversalAnalyticsWrapper {
   @AnalyticsLibraryWrapperTrackEvent(uaLogger)
   public static trackEvent(category: string, action: string, label?: string, value?: string | number): void {
     if (!this.isUserAgentSet) {
-      uaLogger.error('User Agent needs to be set before calling Analytics.trackEvent');
+      uaLogger.warn('User Agent needs to be set before calling Analytics.trackEvent');
       return;
     }
 


### PR DESCRIPTION
When trackEvent logs the message, some errors for the root cause are published before trackEvent, and it's difficult to find the wanted error message if too many errors from trackEvent exist.