### PR TITLE
Specify ubuntu-20.04 instead of ubuntu-latest which is changed to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci-on-ubuntu.yml
+++ b/.github/workflows/ci-on-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # for electron-builder

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: automatic merge on CI success
     conditions:
-      - status-success=test (ubuntu-latest)
+      - status-success=test (ubuntu-20.04)
       - status-success=test (windows-latest)
       - status-success=test (macOS-latest)
       - label=automerge


### PR DESCRIPTION
With `ubuntu-latest`, there was an issue during `npm run test:package` like below:
```
dlopen(): error loading libfuse.so.2

AppImages require FUSE to run. 
```
https://github.com/TomoyukiAota/photo-location-map/actions/runs/3546763738/jobs/5956142617

This is because `ubuntu-latest` is changed from Ubuntu 20.04 to Ubuntu 22.04, and Ubuntu 22.04 does not have libfuse2 required for AppImage.
This PR reverts to use Ubuntu 20.04 in order to avoid the issue.

References:
 - https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/
 - https://askubuntu.com/questions/1403811/appimage-on-ubuntu-22-04
 - https://itsfoss.com/cant-run-appimage-ubuntu/