### PR TITLE
Add a line break in the zoom slider's label.

### DIFF
--- a/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
+++ b/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
@@ -150,8 +150,12 @@ export class DateTimeTakenChartComponent {
           end: 100
         },
         {
+          type: 'slider',
           start: 0,
-          end: 100
+          end: 100,
+          labelFormatter: (_, valueStr) => {
+            return valueStr.replace(' ', '\n');
+          },
         }
       ],
       series: [


### PR DESCRIPTION
This PR adds a line break in the label for the zoom slider.
In the attached images below, see the label "2020/05/06 22:54:45" at the right-hand side of the zoom slider.

Before: 
<img width="1159" alt="スクリーンショット 2023-09-22 0 14 16" src="https://github.com/TomoyukiAota/photo-location-map/assets/25931120/5bdbf0ce-1d56-4d1b-883b-34fb1bd6ac75">


After: 
<img width="1166" alt="スクリーンショット 2023-09-22 0 10 17" src="https://github.com/TomoyukiAota/photo-location-map/assets/25931120/6fe55892-3ea7-4100-9e46-8541792f41de">

