### PR TITLE
Add a line break between date and time in X-axis label.

### DIFF
--- a/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
+++ b/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
@@ -105,7 +105,7 @@ export class DateTimeTakenChartComponent {
     const option: EChartsOption = {
       grid: {
         top: 25,
-        bottom: 70,
+        bottom: 80,
         left: 90,
         right: 200,
       },
@@ -134,6 +134,9 @@ export class DateTimeTakenChartComponent {
       xAxis: {
         type: 'category',
         data: xData,
+        axisLabel: {
+          formatter: (value: string) => value.replace(' ', '\n'),
+        },
         axisTick: {
           alignWithLabel: true,
         }

--- a/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
+++ b/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
@@ -156,9 +156,7 @@ export class DateTimeTakenChartComponent {
           type: 'slider',
           start: 0,
           end: 100,
-          labelFormatter: (_, valueStr) => {
-            return valueStr.replace(' ', '\n');
-          },
+          labelFormatter: (_, valueStr) => valueStr.replace(' ', '\n'),
         }
       ],
       series: [

--- a/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
+++ b/src/app/date-time-taken-chart/date-time-taken-chart.component.ts
@@ -135,7 +135,9 @@ export class DateTimeTakenChartComponent {
         type: 'category',
         data: xData,
         axisLabel: {
-          formatter: (value: string) => value.replace(' ', '\n'),
+          formatter: (value: string) => {
+            return value.replace(' ', '\n'); // Add a line break between date and time.
+          },
         },
         axisTick: {
           alignWithLabel: true,
@@ -156,7 +158,9 @@ export class DateTimeTakenChartComponent {
           type: 'slider',
           start: 0,
           end: 100,
-          labelFormatter: (_, valueStr) => valueStr.replace(' ', '\n'),
+          labelFormatter: (_, valueStr) => {
+            return valueStr.replace(' ', '\n'); // Add a line break between date and time.
+          },
         }
       ],
       series: [


### PR DESCRIPTION
With this PR, the date (e.g. 2020-05-06) and the time (e.g. 22:45) are displayed in two lines in the X-axis label.

<img width="1114" alt="スクリーンショット 2023-09-22 4 01 01" src="https://github.com/TomoyukiAota/photo-location-map/assets/25931120/bdcb4408-83c3-44cf-adca-35ac9c87804a">
