### PR TITLE
Fix thumbnail generation failure for HEIC photos taken by iPhone 15 with iOS 18.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "electron-window-state": "5.0.3",
         "exifr": "7.1.3",
         "fs-extra": "11.1.0",
-        "heic-decode": "1.1.2",
+        "heic-decode": "2.0.0",
         "is-natural-number": "4.0.1",
         "is-number": "7.0.0",
         "jimp": "0.16.2",
@@ -17237,11 +17237,12 @@
       }
     },
     "node_modules/heic-decode": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-1.1.2.tgz",
-      "integrity": "sha512-UF8teegxvzQPdSTcx5frIUhitNDliz/9Pui0JFdIqVRE00spVE33DcCYtZqaLNyd4y5RP/QQWZFIc1YWVKKm2A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.0.0.tgz",
+      "integrity": "sha512-NU+zsiDvdL+EebyTjrEqjkO2XYI7FgLhQzsbmO8dnnYce3S0PBSDm/ZyI4KpcGPXYEdb5W72vp/AQFuc4F8ASg==",
+      "license": "ISC",
       "dependencies": {
-        "libheif-js": "^1.10.0"
+        "libheif-js": "^1.17.1"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -19393,9 +19394,10 @@
       }
     },
     "node_modules/libheif-js": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.14.0.tgz",
-      "integrity": "sha512-BhVY8TXRs9ozs9AKEe7AALaOb4fWtkoK+wur25BU5HzWVaxmbHGSCxrFbtngpodfjJRPrlPfE7tZ/b37vYeTSQ==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.18.2.tgz",
+      "integrity": "sha512-4Nk0dKhhRfVS4mECcX2jSDpNU6gcHQLneJjkGQq61N8COGtjSpSA3CI+1Q3kUYv5Vf+SwIqUtaDSdU6JO37c6w==",
+      "license": "LGPL-3.0",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -40289,11 +40291,11 @@
       "dev": true
     },
     "heic-decode": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-1.1.2.tgz",
-      "integrity": "sha512-UF8teegxvzQPdSTcx5frIUhitNDliz/9Pui0JFdIqVRE00spVE33DcCYtZqaLNyd4y5RP/QQWZFIc1YWVKKm2A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.0.0.tgz",
+      "integrity": "sha512-NU+zsiDvdL+EebyTjrEqjkO2XYI7FgLhQzsbmO8dnnYce3S0PBSDm/ZyI4KpcGPXYEdb5W72vp/AQFuc4F8ASg==",
       "requires": {
-        "libheif-js": "^1.10.0"
+        "libheif-js": "^1.17.1"
       }
     },
     "highlight-es": {
@@ -41893,9 +41895,9 @@
       }
     },
     "libheif-js": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.14.0.tgz",
-      "integrity": "sha512-BhVY8TXRs9ozs9AKEe7AALaOb4fWtkoK+wur25BU5HzWVaxmbHGSCxrFbtngpodfjJRPrlPfE7tZ/b37vYeTSQ=="
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.18.2.tgz",
+      "integrity": "sha512-4Nk0dKhhRfVS4mECcX2jSDpNU6gcHQLneJjkGQq61N8COGtjSpSA3CI+1Q3kUYv5Vf+SwIqUtaDSdU6JO37c6w=="
     },
     "license-webpack-plugin": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "electron-window-state": "5.0.3",
     "exifr": "7.1.3",
     "fs-extra": "11.1.0",
-    "heic-decode": "1.1.2",
+    "heic-decode": "2.0.0",
     "is-natural-number": "4.0.1",
     "is-number": "7.0.0",
     "jimp": "0.16.2",


### PR DESCRIPTION
To fix this issue, libheif (libheif-js) v1.18.0 or greater is required.
See libheif-js v1.18.2 specified in package-lock.json.

The following things are done:

1. Update package.json to have heic-decode v2.0.0
2. Run "npm install"

Then, libheif-js v1.18.2 was installed as of October 14, 2024.