### PR TITLE
Remove Bing Maps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
         "karma-jasmine": "5.1.0",
         "karma-jasmine-html-reporter": "2.1.0",
         "karma-mocha-reporter": "2.2.5",
-        "leaflet-plugins": "3.4.0",
         "mixpanel-browser": "2.45.0",
         "ng-mocks": "14.13.1",
         "ng-table-virtual-scroll": "1.6.1",
@@ -18689,12 +18688,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/leaflet-plugins": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/leaflet-plugins/-/leaflet-plugins-3.4.0.tgz",
-      "integrity": "sha512-CjsQKaW545tNY4JVm4v3WhbFcUa2QzWQQzEysQ0eY/ThYYMqIL5DnQNgcHCvAFZtEwlj7MlTtI7BFuKiNuqyJA==",
-      "dev": true
     },
     "node_modules/less": {
       "version": "4.2.0",
@@ -40744,12 +40737,6 @@
           }
         }
       }
-    },
-    "leaflet-plugins": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/leaflet-plugins/-/leaflet-plugins-3.4.0.tgz",
-      "integrity": "sha512-CjsQKaW545tNY4JVm4v3WhbFcUa2QzWQQzEysQ0eY/ThYYMqIL5DnQNgcHCvAFZtEwlj7MlTtI7BFuKiNuqyJA==",
-      "dev": true
     },
     "less": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.1.0",
     "karma-mocha-reporter": "2.2.5",
-    "leaflet-plugins": "3.4.0",
     "mixpanel-browser": "2.45.0",
     "ng-mocks": "14.13.1",
     "ng-table-virtual-scroll": "1.6.1",


### PR DESCRIPTION
This is because those who are using Bing Maps for Enterprise Basic or Free account will no longer be able to use Bing Maps for Enterprise services beyond June 30, 2025, which is stated in the email received on December 6, 2024.