### PR TITLE
Change the order of URLs to fetch raster-tile-base-layer-configs-version-1.jsonc

### DIFF
--- a/src/app/map/leaflet-map/raster-tile-base-layer-configs-version-1.ts
+++ b/src/app/map/leaflet-map/raster-tile-base-layer-configs-version-1.ts
@@ -56,14 +56,14 @@ export const rasterTileBaseLayerConfigsVersion1Fallback: RasterTileBaseLayerConf
 // In the development environment, the content of the feature branch can be used as needed.
 const configsFileFetchArguments: Array<{ url: string, options: RequestInit }> = [
   {
-    url: 'https://cdn.jsdelivr.net/gh/TomoyukiAota/photo-location-map-resources@main/map-configs/raster-tile-base-layer-configs-version-1.jsonc',
+    url: 'https://raw.githubusercontent.com/TomoyukiAota/photo-location-map-resources/refs/heads/main/map-configs/raster-tile-base-layer-configs-version-1.jsonc',
     options: {
       cache: 'no-store',
       signal: AbortSignal.timeout(10000 /* milliseconds */),
     },
   },
   {
-    url: 'https://raw.githubusercontent.com/TomoyukiAota/photo-location-map-resources/refs/heads/main/map-configs/raster-tile-base-layer-configs-version-1.jsonc',
+    url: 'https://cdn.jsdelivr.net/gh/TomoyukiAota/photo-location-map-resources@main/map-configs/raster-tile-base-layer-configs-version-1.jsonc',
     options: {
       cache: 'no-store',
       // No timeout for the last attempt.


### PR DESCRIPTION
After changing the content of raster-tile-base-layer-configs-version-1.jsonc in photo-location-map-resources repo, I tried purging the cache for jsDelivr.
However, after 1 hour, jsDelivr still returns the old content.
It seems it takes too much time for purging jsDelivr's cache to take effect.
On the other hand, githubusercontent already returns the new content without instructing it to "purge cache".
Therefore, githubusercontent is set to the first URL instead of jsDelivr.