### PR TITLE
Support macOS on Apple Silicon in CI. Introduce mise.

### DIFF
--- a/.github/workflows/ci-on-mac.yml
+++ b/.github/workflows/ci-on-mac.yml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false    # To see the result on both architectures even when one of them fails
       matrix:
-        os: [macos-26-intel]
+        os: [macos-26, macos-26-intel]    # macos-26 is arm64 (Apple Silicon), and macos-26-intel is x64.
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # for electron-builder

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - status-success=test (ubuntu-24.04)
       - status-success=test (windows-latest)
+      - status-success=test (macos-26)
       - status-success=test (macos-26-intel)
       - label=automerge
       - author=TomoyukiAota

--- a/angular.json
+++ b/angular.json
@@ -154,6 +154,7 @@
   "cli": {
     "schematicCollections": [
       "@angular-eslint/schematics"
-    ]
+    ],
+    "analytics": false
   }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+node = "20.16.0"   # Keep in sync with the Node.js version in .github/workflows/ci-on-*.yml

--- a/script/package-test/package-test-info.js
+++ b/script/package-test/package-test-info.js
@@ -2,10 +2,6 @@ const path = require('path');
 const { version } = require('../../package.json');
 const getLogDirectory = require('./get-log-directory');
 
-// electron-builder appends the arch to the package name, except when the target arch is the default arch (x64).
-// Note that this assumes x64 or arm64. electron-builder can use different names for other arches (e.g. ia32, armv7l).
-const archSuffix = global.process.arch === 'x64' ? '' : `-${global.process.arch}`;
-
 class PackageTestInfo {
   constructor() {
     this.distDirectory = `.${path.sep}dist`;
@@ -15,6 +11,10 @@ class PackageTestInfo {
   }
 
   addMiscPlatformDependentProperties() {
+    // electron-builder appends the arch to the package name, except when the target arch is the default arch (x64).
+    // Note that this assumes x64 or arm64. electron-builder can use different names for other arches (e.g. ia32, armv7l).
+    const archSuffix = global.process.arch === 'x64' ? '' : `-${global.process.arch}`;
+
     switch(global.process.platform) {
       case 'win32':
         this.packageCreationCommand = 'npm run package:windows';

--- a/script/package-test/package-test-info.js
+++ b/script/package-test/package-test-info.js
@@ -2,6 +2,10 @@ const path = require('path');
 const { version } = require('../../package.json');
 const getLogDirectory = require('./get-log-directory');
 
+// electron-builder appends the arch to the package name, except when the target arch is the default arch (x64).
+// Note that this assumes x64 or arm64. electron-builder can use different names for other arches (e.g. ia32, armv7l).
+const archSuffix = global.process.arch === 'x64' ? '' : `-${global.process.arch}`;
+
 class PackageTestInfo {
   constructor() {
     this.distDirectory = `.${path.sep}dist`;
@@ -20,14 +24,14 @@ class PackageTestInfo {
         break;
       case 'darwin':
         this.packageCreationCommand = 'npm run package:mac';
-        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}.dmg`;
-        this.executablePrelaunchCommand = `hdiutil attach "${this.releaseDirectory}/Photo Location Map-${version}.dmg"`;
-        this.executableLaunchCommand = `open -W "/Volumes/Photo Location Map ${version}/Photo Location Map.app"`;
+        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.dmg`;
+        this.executablePrelaunchCommand = `hdiutil attach "${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.dmg"`;
+        this.executableLaunchCommand = `open -W "/Volumes/Photo Location Map ${version}${archSuffix}/Photo Location Map.app"`;
         break;
       case 'linux':
         this.packageCreationCommand = 'npm run package:linux';
-        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}.AppImage`;
-        this.executableLaunchCommand = `"${this.releaseDirectory}/Photo Location Map-${version}.AppImage"`;
+        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.AppImage`;
+        this.executableLaunchCommand = `"${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.AppImage"`;
         break;
       default:
         throw new Error(`Unsupported platform for "${__filename}"`);


### PR DESCRIPTION
## Summary

Set up this repository for development on an arm64 (Apple Silicon) Mac.

- **Introduce `mise.toml`** pinning Node.js to 20.16.0, which is the same version as the one used in the CI workflows. This makes the Node.js version for local development reproducible without adding any step to CI.
- **Fix `npm run test:package` failing on arm64 macOS.** The expected package location and the executable launch command were hard-coded for x64.
- **Run the macOS CI on Apple Silicon** by adding `macos-26` to the matrix, so that the arm64 path is covered from now on.
- **Disable Angular CLI analytics** via `"analytics": false` in `angular.json`.

## Details of the package test fix

electron-builder appends the arch to the package name unless the target arch is the default arch (x64). The same applies to the DMG volume name. On arm64 macOS, this means:

| | x64 | arm64 |
|--|--|--|
| Package | `Photo Location Map-<version>.dmg` | `Photo Location Map-<version>-arm64.dmg` |
| Volume  | `/Volumes/Photo Location Map <version>` | `/Volumes/Photo Location Map <version>-arm64` |

The package test expected the x64 names, so the package creation test failed on arm64 macOS, and the smoke test would have failed next when mounting the DMG.

The arch suffix is now derived at run time. For x64, the resolved strings are exactly identical to the previous ones, so the behavior on the existing runners is unchanged. Linux (AppImage) has the same issue latently, so it is covered by the same change. Windows needs no change because the default NSIS artifact name does not include the arch.

## Adding Apple Silicon to CI

`macos-26` is the Apple Silicon (arm64) runner, and `macos-26-intel` is the Intel (x64) one. Both are now in the matrix of `CI on macOS`, with `fail-fast: false` so that a failure on one architecture does not cancel the other.

`.mergify.yml` now also requires `test (macos-26)`. Mergify reads its configuration from the default branch only, so this takes effect for the pull requests after this one is merged.

### Follow-up needed after merging

The branch protection of `main` requires `test (windows-latest)`, `test (ubuntu-24.04)` and `test (macos-26-intel)`. **`test (macos-26)` needs to be added to the required status checks** in the repository settings after merging this pull request. Until then, the arm64 job is reported but is not a merge blocker.

## Test plan

- `npm run test:all` passes locally on arm64 macOS.
- CI passes on Apple Silicon macOS, Intel macOS, Ubuntu and Windows.
- The macOS CI log confirms that each architecture resolves its own package name:
  - `test (macos-26)`: `Expected Package Location: "./release/Photo Location Map-1.11.1-alpha-arm64.dmg"`
  - `test (macos-26-intel)`: `Expected Package Location: "./release/Photo Location Map-1.11.1-alpha.dmg"`

## Out of scope

macOS release packages are created locally, not by CI. Once they are created on an Apple Silicon Mac, the artifact name gains the `-arm64` suffix and no x64 build is produced, which affects the hard-coded download link in `docs/github-pages/download.js`. Deciding between a universal build and distributing both architectures is left to a separate pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)