### PR TITLE
Use Universal Binary for macOS

### DIFF
--- a/docs/github-pages/download.js
+++ b/docs/github-pages/download.js
@@ -11,6 +11,7 @@ const version = '1.11.0';
 const downloadDirectory = `https://github.com/TomoyukiAota/photo-location-map/releases/download/v${version}`;
 const downloadLink = {
   win: `${downloadDirectory}/Photo-Location-Map-Setup-${version}.exe`,
+  // The macOS package is a universal build from v1.11.1 onwards, and "-universal" needs to be added to the file name below when the version above is updated to v1.11.1 or later.
   mac: `${downloadDirectory}/Photo-Location-Map-${version}.dmg`
 };
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -23,7 +23,12 @@
   "mac": {
     "icon": "dist",
     "target": [
-      "dmg"
+      {
+        "target": "dmg",
+        "arch": [
+          "universal"
+        ]
+      }
     ],
     "notarize": false,
     "hardenedRuntime": true,

--- a/script/package-test/package-test-info.js
+++ b/script/package-test/package-test-info.js
@@ -11,10 +11,6 @@ class PackageTestInfo {
   }
 
   addMiscPlatformDependentProperties() {
-    // electron-builder appends the arch to the package name, except when the target arch is the default arch (x64).
-    // Note that this assumes x64 or arm64. electron-builder can use different names for other arches (e.g. ia32, armv7l).
-    const archSuffix = global.process.arch === 'x64' ? '' : `-${global.process.arch}`;
-
     switch(global.process.platform) {
       case 'win32':
         this.packageCreationCommand = 'npm run package:windows';
@@ -24,15 +20,19 @@ class PackageTestInfo {
         break;
       case 'darwin':
         this.packageCreationCommand = 'npm run package:mac';
-        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.dmg`;
-        this.executablePrelaunchCommand = `hdiutil attach "${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.dmg"`;
-        this.executableLaunchCommand = `open -W "/Volumes/Photo Location Map ${version}${archSuffix}/Photo Location Map.app"`;
+        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}-universal.dmg`;
+        this.executablePrelaunchCommand = `hdiutil attach "${this.releaseDirectory}/Photo Location Map-${version}-universal.dmg"`;
+        this.executableLaunchCommand = `open -W "/Volumes/Photo Location Map ${version}-universal/Photo Location Map.app"`;
         break;
-      case 'linux':
+      case 'linux': {
+        // electron-builder appends the arch to the package name, except when the target arch is the default arch (x64).
+        // Note that this assumes x64 or arm64. electron-builder can use different names for other arches (e.g. ia32, armv7l).
+        const archSuffix = global.process.arch === 'x64' ? '' : `-${global.process.arch}`;
         this.packageCreationCommand = 'npm run package:linux';
         this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.AppImage`;
         this.executableLaunchCommand = `"${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.AppImage"`;
         break;
+      }
       default:
         throw new Error(`Unsupported platform for "${__filename}"`);
     }


### PR DESCRIPTION
## Summary

Build the macOS package as a Universal Binary so that one DMG runs natively on both Apple Silicon and Intel Macs.

Until now, `npm run package:mac` produced a package for the arch of the machine creating it. Since macOS packages are created locally rather than by CI, moving development to an Apple Silicon Mac would have made the released package arm64-only, leaving Intel users without a build.

## Changes

- **`electron-builder.json`**: the `mac` target is now `dmg` with `arch: ["universal"]`.
- **`script/package-test/package-test-info.js`**: a universal build always gets the `-universal` suffix regardless of the arch of the machine creating it, so the macOS package name is no longer derived from `process.arch`. The `archSuffix` derivation is now used by Linux only, and its definition moved into the `linux` case.
- **`docs/github-pages/download.js`**: a comment only. See below.

## Package size

Measured on this branch:

| | DMG | `.app` |
|--|--:|--:|
| arm64 only (before) | 112 MB | 298 MB |
| universal (after) | 193 MB | 480 MB |
| | +81 MB (1.72x) | +182 MB (1.61x) |

Every user downloads about 81 MB more than they need for their own architecture. This is accepted in exchange for a single package that works everywhere and a download page that needs no architecture switching.

## The download link is intentionally left unchanged

`docs/github-pages/download.js` still points at `Photo-Location-Map-${version}.dmg`. The currently published v1.11.0 package is not a universal build, so adding `-universal` now would immediately break the download button on the live page.

**`-universal` needs to be added to the macOS link at the same time as the version in that file is bumped to v1.11.1 or later.** A comment is added next to the link as a reminder. The published asset name will be `Photo-Location-Map-<version>-universal.dmg`, since electron-builder replaces the spaces with hyphens when uploading.

## Test plan

- `npm run test:package` passes locally on Apple Silicon, creating and launching `Photo Location Map-1.11.1-alpha-universal.dmg`.
- `lipo -archs` confirms both slices are present:
  - `Photo Location Map` executable: `x86_64 arm64`
  - `Electron Framework`: `x86_64 arm64`
- CI creates the same universal package on both `macos-26` (arm64) and `macos-26-intel` (x64), and the smoke test launches it natively on each, so both slices are exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)