### PR TITLE
Install Node.js with mise in CI, and improve the package test logging

### DIFF
--- a/.github/workflows/ci-on-mac.yml
+++ b/.github/workflows/ci-on-mac.yml
@@ -21,12 +21,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # for electron-builder
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
-    - name: Use Node.js 20.16.0
-      uses: actions/setup-node@v1
-      with:
-        node-version: 20.16.0
+    - name: Install Node.js with the version in mise.toml
+      uses: jdx/mise-action@v4
 
     - name: npm ci
       run: npm ci

--- a/.github/workflows/ci-on-ubuntu.yml
+++ b/.github/workflows/ci-on-ubuntu.yml
@@ -21,12 +21,10 @@ jobs:
       ELECTRON_DISABLE_SANDBOX: '1'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
-    - name: Use Node.js 20.16.0
-      uses: actions/setup-node@v1
-      with:
-        node-version: 20.16.0
+    - name: Install Node.js with the version in mise.toml
+      uses: jdx/mise-action@v4
 
     - name: npm ci
       run: npm ci

--- a/.github/workflows/ci-on-windows.yml
+++ b/.github/workflows/ci-on-windows.yml
@@ -20,12 +20,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # for electron-builder
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
-    - name: Use Node.js 20.16.0
-      uses: actions/setup-node@v1
-      with:
-        node-version: 20.16.0
+    - name: Install Node.js with the version in mise.toml
+      uses: jdx/mise-action@v4
 
     - name: npm ci
       run: npm ci

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,8 +22,8 @@ This page contains useful information to contribute to this project.
 ## Prerequisite
 
  - Node.js (64-bit), with the version specified in [`mise.toml`](../mise.toml)
-   - [mise](https://mise.jdx.dev/) is the recommended way to install it. `mise.toml` is the single source of truth of the Node.js version, and CI installs the same version from it.
-   - Installing Node.js in another way also works as long as the version matches.
+   - [mise](https://mise.jdx.dev/) is the recommended way to install it. `mise.toml` is the single source of truth for the Node.js version, and CI installs the same version from it.
+   - Node.js can also be installed however you prefer, as long as the version matches.
  - More than 2GB of RAM
    - Application packaging frequently fails on a PC with 1GB of RAM. Add more RAM depending on the available memory for application packaging on your PC.
 
@@ -39,7 +39,7 @@ npm ci
 npm start
 ```
 
-Without mise, install Node.js by another way, and then run `npm ci` and `npm start`.
+Without mise, install Node.js however you prefer, and then run `npm ci` and `npm start`.
 
 
 ## Frequently Used Commands

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,7 +21,9 @@ This page contains useful information to contribute to this project.
 
 ## Prerequisite
 
- - Node.js (64-bit, version 20.16.0 or greater)
+ - Node.js (64-bit), with the version specified in [`mise.toml`](../mise.toml)
+   - [mise](https://mise.jdx.dev/) is the recommended way to install it. `mise.toml` is the single source of truth of the Node.js version, and CI installs the same version from it.
+   - Installing Node.js in another way also works as long as the version matches.
  - More than 2GB of RAM
    - Application packaging frequently fails on a PC with 1GB of RAM. Add more RAM depending on the available memory for application packaging on your PC.
 
@@ -31,9 +33,13 @@ This page contains useful information to contribute to this project.
 After cloning this repository, run these commands to start the application: 
 
 ``` bash
+mise trust    # Only needed once per clone, to allow mise to read mise.toml
+mise install  # Install Node.js with the version in mise.toml
 npm ci
 npm start
 ```
+
+Without mise, install Node.js by another way, and then run `npm ci` and `npm start`.
 
 
 ## Frequently Used Commands

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = "20.16.0"   # The single source of truth of the Node.js version. CI installs this version with jdx/mise-action.
+node = "20.16.0"   # The single source of truth for the Node.js version. CI installs this version with jdx/mise-action.

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = "20.16.0"   # Keep in sync with the Node.js version in .github/workflows/ci-on-*.yml
+node = "20.16.0"   # The single source of truth of the Node.js version. CI installs this version with jdx/mise-action.

--- a/script/util/run-command-sync.js
+++ b/script/util/run-command-sync.js
@@ -3,8 +3,9 @@ const logger = require('./logger');
 
 const runCommandSync = (command, startMsg, endMsg) => {
   logger.info(startMsg);
-  const stdout = child_process.execSync(command);
-  console.info(stdout.toString());
+  // "inherit" is used to print the output while the command is running.
+  // Without it, the output is captured and printed only when the command succeeds, which hides the reason of a failure.
+  child_process.execSync(command, {stdio: 'inherit'});
   logger.info(endMsg);
 };
 


### PR DESCRIPTION
## Summary

Follow-up improvements to the documentation and CI after introducing mise, plus a fix for a logging problem in the package test that made a CI failure impossible to diagnose.

## 1. Print the output of the command while it is running in the package test

`script/util/run-command-sync.js` used `execSync(command)`, which captures the stdout and prints it only after the command succeeds:

```js
const stdout = child_process.execSync(command);
console.info(stdout.toString());   // Not reached when the command fails
```

When `npm run package:mac` failed on the `macos-26-intel` runner of #595, the electron-builder output was discarded, and the log only showed `Error: Command failed: npm run package:mac` after 13 minutes with no reason. The Angular warnings that were visible came from stderr.

`stdio: 'inherit'` is now used, so the output is printed while the command runs and the reason of a failure stays in the log. It also removes the 1 MB `maxBuffer` limit of the captured stdout and makes the progress of these long steps visible in real time.

## 2. Install Node.js with mise in CI

The Node.js version was written in four places: `mise.toml` and each of the three workflows. `jdx/mise-action` installs the version in `mise.toml`, so `mise.toml` is now the single source of truth for both local development and CI, and the version can be updated in one place.

`actions/checkout` is updated from v2 to v7 at the same time, since both are in the same part of every workflow.

## 3. Describe how to set up the development environment with mise

`docs/CONTRIBUTING.md` still described only the Node.js version. It now points at `mise.toml` and shows the setup commands. `mise trust` is included because mise refuses to read a config file in a freshly cloned repository until it is trusted.

Installing Node.js without mise is still supported and documented.

## Test plan

- `npm run lint:script` passes.
- All the workflow files are validated as YAML.
- `runCommandSync` is verified locally to print the child output on success and to still throw on a non-zero exit.
- CI on all four platform jobs is the real verification of the mise-action change, since it must install Node.js 20.16.0 on macOS (arm64 and x64), Ubuntu and Windows.

## Note

`mise-action` sets `MISE_TRUSTED_CONFIG_PATHS` and `MISE_YES` itself, so no explicit trust step is needed in the workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)