### PR TITLE
Add com.apple.security.cs.allow-jit to the entitlements for macOS

### DIFF
--- a/script/notarize/entitlements.mac.plist
+++ b/script/notarize/entitlements.mac.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <!-- Required by the JIT of V8. On Apple Silicon, allow-unsigned-executable-memory is not enough,
+         and the application crashes in v8::Isolate::Initialize without allow-jit when the hardened runtime is enabled. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
   </dict>


### PR DESCRIPTION
## Summary

The signed macOS application crashes immediately on Apple Silicon because the entitlements do not include `com.apple.security.cs.allow-jit`.

This blocks the release of the Universal Binary introduced in #595.

## The crash

Launching the signed `.app` from the DMG produces no log file, and a crash report is written:

```
exception:       EXC_BREAKPOINT (SIGTRAP)
faulting thread: com.apple.main-thread
  ...
  v8::Isolate::Initialize(v8::Isolate*, v8::Isolate::CreateParams const&)
```

The crash report shows `codeSigningFlags: 0x22012311`, which has `CS_RUNTIME` set, and the signed application carries only one entitlement:

```
com.apple.security.cs.allow-unsigned-executable-memory
```

On Apple Silicon, this is not enough for the JIT of V8. `com.apple.security.cs.allow-jit` is required, and the hardened runtime kills the process when V8 initializes without it. On x64, `allow-unsigned-executable-memory` alone is sufficient, so this entitlement was never needed until now.

## Why this was never seen before

Three conditions have to hold at the same time:

1. The application is signed, so the hardened runtime is enforced
2. It runs natively on arm64
3. `allow-jit` is missing

| | Result |
|--|--|
| Released packages so far (x64 only) | Run through Rosetta on Apple Silicon, so not affected |
| Local builds before the signing certificate was set up | Unsigned, so the hardened runtime is not enforced |
| Universal build, signed | **Crashes on Apple Silicon** |

The problem appeared only after the signing certificate was installed on an Apple Silicon Mac and the Universal Binary was signed for the first time.

## Fix

`com.apple.security.cs.allow-jit` is added. `com.apple.security.cs.allow-unsigned-executable-memory` is kept, since the x64 slice of the Universal Binary still needs it.

## Test plan

`npm run test:package` on Apple Silicon, with the Developer ID certificate installed so that the package is actually signed:

- Before the fix: the smoke test fails with `Log file (*_log.txt) is not found.`, and a crash report is written
- After the fix: the smoke test passes, with both `[Main]` and `[Renderer]` logged, and no crash report is written

Both entitlements are confirmed to be applied to the main application and to `Photo Location Map Helper (Renderer).app`.

## Note on CI

**CI cannot catch this class of regression.** No signing certificate is available on the runners, so `skipped macOS application code signing` is logged and the hardened runtime is never enforced. The package test passes on CI both with and without this fix. Verifying it requires a signed build on an Apple Silicon machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)