### PR TITLE
Create the zip package for macOS, which electron-updater requires to auto-update.

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -28,6 +28,12 @@
         "arch": [
           "universal"
         ]
+      },
+      {
+        "target": "zip",
+        "arch": [
+          "universal"
+        ]
       }
     ],
     "notarize": false,

--- a/script/package-test/package-creation-test.js
+++ b/script/package-test/package-creation-test.js
@@ -13,22 +13,24 @@ class PackageCreationTest {
     );
   }
 
-  testIfPackageExists() {
+  testIfPackagesExist() {
     testUtil.printItemsInDirectory(testInfo.releaseDirectory);
-    logger.info(`Expected Package Location: "${testInfo.expectedPackageLocation}"`);
-    if (fs.existsSync(testInfo.expectedPackageLocation)) {
-      logger.info('Package exists in the expected location.');
-    } else {
-      const errorMessage = 'Package does NOT exist in the expected location.';
-      logger.error(errorMessage);
-      throw new Error(errorMessage);
-    }
+    testInfo.expectedPackageLocations.forEach(expectedPackageLocation => {
+      logger.info(`Expected Package Location: "${expectedPackageLocation}"`);
+      if (fs.existsSync(expectedPackageLocation)) {
+        logger.info('Package exists in the expected location.');
+      } else {
+        const errorMessage = `Package does NOT exist in the expected location "${expectedPackageLocation}".`;
+        logger.error(errorMessage);
+        throw new Error(errorMessage);
+      }
+    });
   }
 
   run() {
     logger.info('Start of package creation test.');
     this.createPackage();
-    this.testIfPackageExists();
+    this.testIfPackagesExist();
     logger.info('End of package creation test.');
   }
 }

--- a/script/package-test/package-test-info.js
+++ b/script/package-test/package-test-info.js
@@ -14,22 +14,27 @@ class PackageTestInfo {
     switch(global.process.platform) {
       case 'win32':
         this.packageCreationCommand = 'npm run package:windows';
-        this.expectedPackageLocation = `${this.releaseDirectory}\\Photo Location Map Setup ${version}.exe`;
+        this.expectedPackageLocations = [`${this.releaseDirectory}\\Photo Location Map Setup ${version}.exe`];
         this.executablePrelaunchCommand = `"${this.releaseDirectory}\\Photo Location Map Setup ${version}.exe" /S`;
         this.executableLaunchCommand = `"${process.env.APPDATA}\\..\\Local\\Programs\\Photo Location Map\\Photo Location Map.exe"`;
         break;
-      case 'darwin':
+      case 'darwin': {
+        // The dmg is the package to install the application manually, and the zip is the package which electron-updater
+        // requires in the release to auto-update on macOS. Both of them need to be created.
+        const dmgLocation = `${this.releaseDirectory}/Photo Location Map-${version}-universal.dmg`;
+        const zipLocation = `${this.releaseDirectory}/Photo Location Map-${version}-universal-mac.zip`;
         this.packageCreationCommand = 'npm run package:mac';
-        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}-universal.dmg`;
-        this.executablePrelaunchCommand = `hdiutil attach "${this.releaseDirectory}/Photo Location Map-${version}-universal.dmg"`;
+        this.expectedPackageLocations = [dmgLocation, zipLocation];
+        this.executablePrelaunchCommand = `hdiutil attach "${dmgLocation}"`;
         this.executableLaunchCommand = `open -W "/Volumes/Photo Location Map ${version}-universal/Photo Location Map.app"`;
         break;
+      }
       case 'linux': {
         // electron-builder appends the arch to the package name, except when the target arch is the default arch (x64).
         // Note that this assumes x64 or arm64. electron-builder can use different names for other arches (e.g. ia32, armv7l).
         const archSuffix = global.process.arch === 'x64' ? '' : `-${global.process.arch}`;
         this.packageCreationCommand = 'npm run package:linux';
-        this.expectedPackageLocation = `${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.AppImage`;
+        this.expectedPackageLocations = [`${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.AppImage`];
         this.executableLaunchCommand = `"${this.releaseDirectory}/Photo Location Map-${version}${archSuffix}.AppImage"`;
         break;
       }


### PR DESCRIPTION
## Problem

Auto-update has never worked on macOS.

The `mac` target in `electron-builder.json` was `dmg` only, so `latest-mac.yml` in each release lists only the dmg. This is the case for v1.9.0, v1.10.0, v1.11.0 and v1.12.0.

electron-updater requires a zip on macOS. `MacUpdater` looks up a zip in `latest-mac.yml` and throws when there is none:

```js
const zipFileInfo = findFile(files, "zip", ["pkg", "dmg"]);
if (zipFileInfo == null) {
    throw newError(`ZIP file not provided: ...`, "ERR_UPDATER_ZIP_FILE_NOT_FOUND");
}
```
(`node_modules/electron-updater/out/MacUpdater.js`)

`autoUpdater.checkForUpdates()` succeeds, and the failure happens in the download which follows it. The rejection is caught and logged in `src-main/auto-update/configure-auto-update.ts`, so macOS users see nothing at all.

This matters now that the macOS package is a Universal Binary. Users who installed v1.12.0 or earlier are running the Intel build through Rosetta, and without auto-update they stay on it unless they download the package manually. Rosetta is available through macOS 27, and starting with macOS 28 it is limited to certain older, unmaintained games.

## Change

- Add the `zip` target for macOS in `electron-builder.json`. The mac `zip` target is created with `isWriteUpdateInfo = true` in app-builder-lib, so the zip is written into `latest-mac.yml`, which is what `MacUpdater` looks for.
- Expect both the dmg and the zip in the package test. `expectedPackageLocation` is changed to `expectedPackageLocations` so that more than one package can be tested. The expected packages for Windows and Linux are unchanged.

The zip file name is `Photo Location Map-<version>-universal-mac.zip`. The default artifact name pattern for an archive is `${productName}-${version}[-${arch}]-${os}.${ext}`, `${os}` is `mac`, and `-universal` is included because the default arch is x64.

No change is needed in the application code. electron-updater fetches `latest-mac.yml` from the latest release regardless of the installed version, and v1.11.0 and v1.12.0 both bundle electron-updater 6.3.4. Existing macOS installations therefore start receiving auto-updates once a release which contains the zip is published.

## Testing

CI verifies that both the dmg and the zip are created, on macos-26 and macos-26-intel.

CI does not verify auto-update itself, and notarization is skipped in the package test. Confirming that the update dialog actually appears requires installing this version and then publishing the next one.

Note that the macOS release assets roughly double in size, since the zip is about as large as the 194 MB dmg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)